### PR TITLE
fix: remove stray brace from gradient-text rule

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -145,4 +145,3 @@ footer{margin-top:2rem;background:linear-gradient(135deg,var(--ask-primary),var(
 /* Utilities */
 .gradient-text{background:linear-gradient(135deg,var(--ask-primary),var(--ask-secondary));-webkit-background-clip:text;background-clip:text;color:transparent}
 
-}


### PR DESCRIPTION
## Summary
- remove stray closing brace after `.gradient-text` rule

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc303a1278832aaf1c45d4b8bab346